### PR TITLE
Handle non-ascii text in generateKeywords()

### DIFF
--- a/src/Xmf/Metagen.php
+++ b/src/Xmf/Metagen.php
@@ -141,7 +141,7 @@ class Metagen
         }
 
         $originalKeywords = preg_split(
-            '/[^a-zA-Z\'"-]+/',
+            '/[^\w\']+/u',
             $text,
             -1,
             PREG_SPLIT_NO_EMPTY


### PR DESCRIPTION
Correct English only bias in Metagen::generateKeywords()