### PR TITLE
Allow Helper to be used before module is installed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,10 @@
 *.RTF	 diff=astextplain
 
 /_archive export-ignore
+/tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .scrutinizer.yml export-ignore
+.travis.yml export-ignore
+phpcs.xml.dist export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 vendor/
 composer.lock
 coverage.clover
+git-phpcs.phar

--- a/src/Module/Helper.php
+++ b/src/Module/Helper.php
@@ -40,8 +40,6 @@ class Helper extends GenericHelper
     {
         static $instance = array();
 
-        //$dirname = strtolower($dirname);
-
         if (!isset($instance[$dirname])) {
             $instance[$dirname] = false;
 
@@ -52,6 +50,17 @@ class Helper extends GenericHelper
                 // otherwise get a GenericHelper instance for dirname
                 if (xoops_isActiveModule($dirname)) {
                     $instance[$dirname] = new static($dirname);
+                } elseif (file_exists(XOOPS_ROOT_PATH . '/modules/' . $dirname . '/xoops_version.php')) {
+                    // module exists but is not installed, do best effort to build a temporary helper
+                    $uninstalledHelper = new static($dirname);
+                    $uninstalledModule = new \XoopsModule();
+                    $uninstalledModule->loadInfoAsVar($dirname, false);
+                    $uninstalledHelper->module = $uninstalledModule;
+                    $uninstalledHelper->object = $uninstalledModule;
+                    $uninstalledHelper->dirname = $dirname;
+                    // don't cache this, so a new call to getHelper() will reload -- i.e. after installed
+                    unset($instance[$dirname]);
+                    return $uninstalledHelper;
                 }
             }
         }

--- a/src/Module/Helper/AbstractHelper.php
+++ b/src/Module/Helper/AbstractHelper.php
@@ -26,6 +26,11 @@ namespace Xmf\Module\Helper;
 abstract class AbstractHelper
 {
     /**
+     * @var string module directory name
+     */
+    protected $dirname;
+
+    /**
      * @var XoopsModule
      */
     protected $module;
@@ -68,6 +73,7 @@ abstract class AbstractHelper
             $this->module = $moduleHandler->getByDirname($dirname);
         }
         if (is_object($this->module)) {
+            $this->dirname = $this->module->getVar('dirname');
             $this->init();
         }
     }
@@ -80,6 +86,16 @@ abstract class AbstractHelper
      * @return void
      */
     abstract public function init();
+
+    /**
+     * Return the dirname for this helper
+     *
+     * @return string|null a dirname
+     */
+    public function dirname()
+    {
+        return $this->dirname;
+    }
 
     /**
      * Set debug option on or off

--- a/src/Module/Helper/GenericHelper.php
+++ b/src/Module/Helper/GenericHelper.php
@@ -31,11 +31,6 @@ use Xmf\Language;
 abstract class GenericHelper extends AbstractHelper
 {
     /**
-     * @var string module directory name
-     */
-    protected $dirname;
-
-    /**
      * @var \XoopsModule
      */
     protected $object;
@@ -58,7 +53,6 @@ abstract class GenericHelper extends AbstractHelper
     public function init()
     {
         $this->object = $this->module;
-        $this->dirname = $this->object->getVar('dirname');
     }
 
     /**


### PR DESCRIPTION
- Xmf\Module\Helper::getHelper('dirname') will work on uninstalled module
- adds dirname() method to all helpers to return dirname in use
- cleanup exported archives (remove tests, ci config files and artifacts)