### PR TITLE
Should read file, not load (string)

### DIFF
--- a/src/Database/TableLoad.php
+++ b/src/Database/TableLoad.php
@@ -85,7 +85,7 @@ class TableLoad
     {
         $count = 0;
 
-        $data = Yaml::loadWrapped($yamlFile); // work with phpmyadmin YAML dumps
+        $data = Yaml::readWrapped($yamlFile); // work with phpmyadmin YAML dumps
         if (false !== $data) {
             $count = static::loadTableFromArray($table, $data);
         }


### PR DESCRIPTION
This error has gone undetected because the symfony/yaml component we use (2.x) accepts a filename to Yaml::parse(). This behavior was deprecated in 2.2 and removed in 3.0.

This issue was discovered in 2.6 where a later version of the component is used.