### PR TITLE
Add proxy support in IPAddress::fromRequest()

### DIFF
--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -49,6 +49,9 @@ class IPAddress
     {
         $ip = (array_key_exists('REMOTE_ADDR', $_SERVER)) ? $_SERVER['REMOTE_ADDR'] : '0.0.0.0';
         $class = get_called_class();
+        $proxyCheck = new ProxyCheck();
+        $proxyIP = $proxyCheck->get();
+        $ip = (false === $proxyIP) ? $ip : $proxyIP;
         $instance = new $class($ip);
         return $instance;
     }

--- a/src/ProxyCheck.php
+++ b/src/ProxyCheck.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ You may not change or alter any portion of this comment or credits
+ of supporting developers from this source code or any supporting source code
+ which is considered copyrighted (c) material of the original comment or credit authors.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+namespace Xmf;
+
+/**
+ * ProxyCheck
+ *
+ * @category  Xmf\ProxyCheck
+ * @package   Xmf
+ * @author    Richard Griffith <richard@geekwright.com>
+ * @copyright 2019 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ */
+class ProxyCheck
+{
+    const PROXY_ENVIRONMENT_VARIABLE = 'PROXY_ENV';
+
+    const FORWARDED = 'HTTP_FORWARDED';
+
+    /** @var string|false header name determines how to process */
+    protected $proxyHeaderName = false;
+
+    /** @var string|false header data to process */
+    protected $proxyHeader = false;
+
+    /**
+     * ProxyCheck constructor.
+     */
+    public function __construct()
+    {
+        /* must declare expected proxy in $xoopsConfig['PROXY_ENV'] */
+        $this->proxyHeaderName = $this->getProxyEnvConfig();
+        $this->proxyHeader = $this->getProxyHeader();
+    }
+
+    /**
+     * Get IP address from proxy header specified in $xoopsConfig['PROXY_ENV']
+     *
+     * Returns proxy revealed valid client address, or false if such address was
+     * not found.
+     *
+     * @return string|false
+     */
+    public function get()
+    {
+        if(false===$this->proxyHeaderName || false===$this->proxyHeader) {
+            return false;
+        }
+        $proxyVars = self::splitOnComma($this->proxyHeader);
+        // only consider the first (left most) value
+        $header = reset($proxyVars);
+        $ip=false;
+        switch ($this->proxyHeaderName) {
+            case static::FORWARDED:
+                $ip = $this->getFor($header);
+                break;
+            default:
+                $ip = $this->getXForwardedFor($header);
+                break;
+        }
+
+        return $ip;
+    }
+
+    /**
+     * Split comma delimited string
+     *
+     * @param string $header
+     *
+     * @return string[]
+     */
+    protected function splitOnComma($header)
+    {
+        $parts = explode(',', $header);
+        return array_map('trim', $parts);
+    }
+
+    /**
+     * get configured proxy environment variable
+     *
+     * @return string|bool
+     */
+    protected function getProxyEnvConfig()
+    {
+        global $xoopsConfig;
+
+        /* must declare expected proxy in $xoopsConfig['PROXY_ENV'] */
+        if (!isset($xoopsConfig[static::PROXY_ENVIRONMENT_VARIABLE])
+            || empty($xoopsConfig[static::PROXY_ENVIRONMENT_VARIABLE])) {
+            return false;
+        }
+        return trim($xoopsConfig[static::PROXY_ENVIRONMENT_VARIABLE]);
+    }
+
+    protected function getProxyHeader()
+    {
+        if (!isset($_SERVER[$this->proxyHeaderName]) || empty($_SERVER[$this->proxyHeaderName])) {
+            return false;
+        }
+        return $_SERVER[$this->proxyHeaderName];
+    }
+
+    /**
+     * Extract 'for' IP address in FORWARDED header as in RFC 7239
+     *
+     * @param string $header
+     *
+     * @return string|false IP address, or false if invalid
+     */
+    protected function getFor($header)
+    {
+        $start = strpos($header, 'for=');
+        if ($start === false) {
+            return false;
+        }
+        $ip = substr($header, $start+4);
+        $end = strpos($ip, ';');
+        if ($end !== false) {
+            $ip = substr($ip, 0, $end);
+        }
+        $ip = trim($ip, '"[] ');
+
+        return $this->validateRoutableIP($ip);
+    }
+
+    /**
+     * Process an X-Forwarded-For or Client-IP style header
+     *
+     * @param string $ip expected to be an IP address
+     *
+     * @return string|false IP address, or false if invalid
+     */
+    protected function getXForwardedFor($ip)
+    {
+        return $this->validateRoutableIP($ip);
+    }
+
+    /**
+     * Validate that an IP address is routable
+     *
+     * @param string $ip an IP address to validate
+     *
+     * @return string|false IP address or false if invalid
+     */
+    protected function validateRoutableIP($ip)
+    {
+        if(!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+            return false;
+        }
+        return $ip;
+    }
+}

--- a/tests/unit/IPAddressTest.php
+++ b/tests/unit/IPAddressTest.php
@@ -54,6 +54,20 @@ class IPAddressTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($testAddress, $actual);
     }
 
+    public function testFromRequestProxy()
+    {
+        global $xoopsConfig;
+        $xoopsConfig['PROXY_ENV'] = 'HTTP_CLIENT_IP';
+        $testAddress = '203.0.113.195';
+        $_SERVER['HTTP_CLIENT_IP'] = $testAddress;
+        $_SERVER['REMOTE_ADDR'] = '10.1.1.1';
+        $instance = IPAddress::fromRequest();
+        $actual = $instance->asReadable();
+        $this->assertEquals($testAddress, $actual);
+        unset($xoopsConfig['PROXY_ENV']);
+        unset($_SERVER['HTTP_CLIENT_IP']);
+    }
+
     public function testAsReadable()
     {
         $this->assertEquals($this->testIPV4, $this->object->asReadable());

--- a/tests/unit/ProxyCheckTest.php
+++ b/tests/unit/ProxyCheckTest.php
@@ -1,0 +1,67 @@
+<?php
+namespace Xmf\Test;
+
+use Xmf\ProxyCheck;
+
+class localProxyCheck extends ProxyCheck
+{
+    public function __construct($name, $header)
+    {
+        $this->proxyHeaderName = $name;
+        $this->proxyHeader = $header;
+    }
+}
+
+class ProxyCheckTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ProxyCheck
+     */
+    protected $object;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->object = new ProxyCheck();
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+    }
+
+    public function testGet()
+    {
+        $ip = $this->object->get();
+        $this->assertFalse($ip);
+    }
+
+    public function getProxyCheckTestData()
+    {
+        return array(
+//          ['name', 'header', 'expected'],
+            ['HTTP_FORWARDED', 'for=192.168.2.60;proto=http;by=203.0.113.43, for=192.0.2.43, for=198.51.100.17', false],
+            ['HTTP_FORWARDED', 'for=203.0.113.195;proto=http;by=203.0.113.43, for=192.0.2.43, for=198.51.100.17', '203.0.113.195'],
+            ['HTTP_FORWARDED', 'for="[2001:db8:85a3:8d3:1319:8a2e:370:7348]";proto=http;by=203.0.113.43', '2001:db8:85a3:8d3:1319:8a2e:370:7348'],
+            ['HTTP_NOT_FORWARDED', 'for="[2001:db8:85a3:8d3:1319:8a2e:370:7348]";proto=http;by=203.0.113.43', false],
+            ['HTTP_CLIENT_IP', '203.0.113.195, 70.41.3.18, 150.172.238.178', '203.0.113.195'],
+            ['STUFF', '2001:db8:85a3:8d3:1319:8a2e:370:7348', '2001:db8:85a3:8d3:1319:8a2e:370:7348'],
+        );
+    }
+
+    /**
+     * @dataProvider getProxyCheckTestData
+     */
+    public function testProxyCheck($name, $header, $expected)
+    {
+        $obj = new localProxyCheck($name, $header);
+        $this->assertSame($expected, $obj->get());
+    }
+
+}


### PR DESCRIPTION
Fixes: #64

The ProxyCheck class added here handles proxied address lookup. ProxyCheck::get() is called in IPAddress::fromRequest().

ProxyCheck is configured using the $xoopsConfig['PROXY_ENV'] key. This should be set consistent with the configuration of the proxy or load balancer controlled by your web server environment.

PROXY_ENV can be set in xoops_data/configs/xoopsconfig.php

An example using the RFC7239 standard would be:
```$xoopsConfig['PROXY_ENV'] = 'HTTP_FORWARDED';```

Note: Trusting proxy information from outside of your control is a security issue that can lead to spoofing and dos attacks.