### PR TITLE
Fix using null as string error

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -553,7 +553,7 @@ class Request
         static $safeHtmlFilter = null;
 
         // convert $var in array if $type is ARRAY
-        if (strtolower($type) === 'array' && !is_array($var)) {
+        if (strtolower((string)$type) === 'array' && !is_array($var)) {
             $var = array($var);
         }
 


### PR DESCRIPTION
This replaces #82

This avoids adding an if statement to the code to help keep complexity (number of paths through the code) down.