### PR TITLE
Handle new table properly in Migrate:getCurrentSchema()

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push pull_request]
 
 jobs:
   phpunit:

--- a/src/Database/Migrate.php
+++ b/src/Database/Migrate.php
@@ -27,8 +27,8 @@ use Xmf\Yaml;
  * @category  Xmf\Database\Migrate
  * @package   Xmf
  * @author    Richard Griffith <richard@geekwright.com>
- * @copyright 2018 XOOPS Project (https://xoops.org)
- * @license   GNU GPL 2 or later (http://www.gnu.org/licenses/gpl-2.0.html)
+ * @copyright 2018-2022 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  * @link      https://xoops.org
  */
 class Migrate
@@ -68,7 +68,18 @@ class Migrate
         if (empty($this->moduleTables)) {
             throw new \RuntimeException("No tables established in module");
         }
-        $version = $module->getInfo('version');
+
+        $version = preg_replace_callback(
+            '/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/',
+            function ($match) {
+                $semver = $match[1] . '_' . $match[2] . '_' .$match[3];
+                if (!empty($match[4])) {
+                    $semver .= '_' . substr($match[4], 0, 8);
+                }
+                return $semver;
+            },
+            $module->getInfo('version'));
+
         $this->tableDefinitionFile = $this->helper->path("sql/{$dirname}_{$version}_migrate.yml");
         $this->tableHandler = new Tables();
     }
@@ -103,7 +114,9 @@ class Migrate
     public function getCurrentSchema()
     {
         foreach ($this->moduleTables as $tableName) {
-            $this->tableHandler->useTable($tableName);
+            if (false === $this->tableHandler->useTable($tableName)) {
+                $this->tableHandler->addTable($tableName);
+            }
         }
 
         return $this->tableHandler->dumpTables();


### PR DESCRIPTION
If table was identified in $modversion['tables'] in xoops_version.php, but did not exist in the database, schema was not applied to the new table.

This is related to the errors mentioned in #85

Also includes fixes for:
- schema errors for column default by MySQL function (i.e. CURRENT_TIMESTAMP)
- tweaks to generated schema file names for new module versioning
- minor docblock cleanups