### PR TITLE
bug in executeQueue()

### DIFF
--- a/src/Database/Tables.php
+++ b/src/Database/Tables.php
@@ -599,8 +599,6 @@ class Tables
             if (!$result) {
                 $this->lastError = $this->db->error();
                 $this->lastErrNo = $this->db->errno();
-
-                return false;
             }
         }
 


### PR DESCRIPTION
"return false" exits the routine on the first error, and it never finishes the execution, i.e. the rest of the tasks in queue won't get executed, e.g. creating new tables