### PR TITLE
feature/if there is no permissionHandler, it crashes

### DIFF
--- a/src/Module/Helper/Permission.php
+++ b/src/Module/Helper/Permission.php
@@ -68,13 +68,17 @@ class Permission extends AbstractHelper
         $gperm_itemid = (int) $gperm_itemid;
         $gperm_groupid = $this->getUserGroups();
 
-        return $this->permissionHandler->checkRight(
-            $gperm_name,
-            $gperm_itemid,
-            $gperm_groupid,
-            $this->mid,
-            (bool) $trueifadmin
-        );
+        if ($this->permissionHandle) {
+            return $this->permissionHandler->checkRight(
+                $gperm_name,
+                $gperm_itemid,
+                $gperm_groupid,
+                $this->mid,
+                (bool)$trueifadmin
+            );
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/src/Module/Helper/Permission.php
+++ b/src/Module/Helper/Permission.php
@@ -68,7 +68,7 @@ class Permission extends AbstractHelper
         $gperm_itemid = (int) $gperm_itemid;
         $gperm_groupid = $this->getUserGroups();
 
-        if ($this->permissionHandle) {
+        if ($this->permissionHandler) {
             return $this->permissionHandler->checkRight(
                 $gperm_name,
                 $gperm_itemid,


### PR DESCRIPTION
It was during installation, as XOOPS was going trough different preloads, it went to \modules\xwhoops25\preloads\core.php
line 30 called the XMF PermissionHelper:
```php
 if ($permissionHelper->checkPermission($permissionName, $permissionItemId, false)) {
```
But because the **permissionHandler** was null here
```php
return $this->permissionHandler->checkRight(
```
it crashed