### PR TITLE
Prep for XoopsCore25 2.5.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
       }
     },
     "require": {
-      "php": ">=5.3.9",
+      "php": ">=5.6.0",
       "kint-php/kint": "^3.3",
       "symfony/yaml": "^2.8",
       "paragonie/random_compat": "^2",


### PR DESCRIPTION
- PHP min version bump to 5.6 (composer autoloader requirement)