### PR TITLE
fix multiple issues found during pre-release review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -43,20 +43,6 @@ reviews:
         Review test code for proper assertions, test isolation, and edge
         case coverage. Tests must remain compatible with this repository's
         supported PHPUnit setup.
-  tools:
-    phpcs:
-      enabled: true
-    phpstan:
-      enabled: true
-    gitleaks:
-      enabled: true
-    markdownlint:
-      enabled: true
-    yamllint:
-      enabled: true
-    github-checks:
-      enabled: true
-      timeout_ms: 90000
 
 chat:
   auto_reply: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix `TableLoad::loadTableFromArray()` to escape backticks in column names, preventing identifier injection
 * Fix `FilterInput::WEBURL` to reject protocol-relative URLs (`//evil.example`) that bypassed scheme validation
 * Fix `Tables::quoteDefaultClause()` to escape single quotes in DDL default values, preventing broken migrations
+* Harden `Serializer::fromLegacy()` gzip decompression with streaming inflate and size-enforced chunking to prevent zip-bomb memory exhaustion
 
 ### Bug Fixes
 * Fix `Metagen::purifyText()` calling `html_entity_decode()` without explicit encoding (now uses `self::ENCODING`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # XMF ChangeLog
 
+## [1.3.0-RC1] - 2026-04-06
+
+### Security
+* Fix wrapped YAML (`dumpWrapped`) using `<?php exit; ?>` guard instead of PHP block comment to prevent code execution when YAML content contains `*/`
+* Fix JWT claim validation using strict comparison (`!==`) to prevent type-juggling bypass in `JsonWebToken::decode()`
+* Fix JWT `TokenReader::fromHeader()` to require `Bearer` scheme for Authorization headers; custom headers still accept bare tokens
+* Fix `TableLoad::loadTableFromArray()` to escape backticks in column names, preventing identifier injection
+* Fix `FilterInput::WEBURL` to reject protocol-relative URLs (`//evil.example`) that bypassed scheme validation
+* Fix `Tables::quoteDefaultClause()` to escape single quotes in DDL default values, preventing broken migrations
+
+### Bug Fixes
+* Fix `Metagen::purifyText()` calling `html_entity_decode()` without explicit encoding (now uses `self::ENCODING`)
+* Fix `Metagen::purifyText()` replacing literal `'\n'` instead of actual newline characters
+* Fix `SendmailRunner` hanging indefinitely when `$rfc822` is empty by closing stdin immediately
+
+### Changed
+* Wrapped YAML files now use `<?php exit; ?>` instead of `<?php /* */ ?>` format; `loadWrapped()` reads both old and new formats transparently
+* Replace `header('HTTP/1.0 404 Not Found')` with `http_response_code(404); exit;` in all directory index guards
+
 ## [1.3.0-beta1] - 2026-02-22
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.3.0-RC1] - 2026-04-06
 
 ### Security
-* Fix wrapped YAML (`dumpWrapped`) using `<?php exit; ?>` guard instead of PHP block comment to prevent code execution when YAML content contains `*/`
+* Fix wrapped YAML (`dumpWrapped`) using `__halt_compiler()` guard instead of PHP block comment to prevent code execution when YAML content contains `*/` or `<?php`
 * Fix JWT claim validation using strict comparison (`!==`) to prevent type-juggling bypass in `JsonWebToken::decode()`
 * Fix JWT `TokenReader::fromHeader()` to require `Bearer` scheme for Authorization headers; custom headers still accept bare tokens
 * Fix `TableLoad::loadTableFromArray()` to escape backticks in column names, preventing identifier injection
@@ -16,8 +16,9 @@
 * Fix `SendmailRunner` hanging indefinitely when `$rfc822` is empty by closing stdin immediately
 
 ### Changed
-* Wrapped YAML files now use `<?php exit; ?>` instead of `<?php /* */ ?>` format; `loadWrapped()` reads both old and new formats transparently
+* Wrapped YAML files now use `<?php __halt_compiler(); ?>` instead of `<?php /* */ ?>` format; `loadWrapped()` reads both old and new formats transparently
 * Replace `header('HTTP/1.0 404 Not Found')` with `http_response_code(404); exit;` in all directory index guards
+* Fix duplicate `tools:` key in `.coderabbit.yaml` causing parse failure
 
 ## [1.3.0-beta1] - 2026-02-22
 

--- a/index.php
+++ b/index.php
@@ -1,2 +1,3 @@
 <?php
-    header('HTTP/1.0 404 Not Found');
+    http_response_code(404);
+    exit;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -97,8 +97,8 @@ parameters:
 			path: src/Database/TableLoad.php
 
 		-
-			message: '#^Binary operation "\." between ''`'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
 			count: 1
 			path: src/Database/TableLoad.php
 
@@ -411,7 +411,7 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 7
+			count: 8
 			path: src/FilterInput.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -411,7 +411,7 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 8
+			count: 7
 			path: src/FilterInput.php
 
 		-
@@ -486,11 +486,6 @@ parameters:
 			count: 1
 			path: src/FilterInput.php
 
-		-
-			message: '#^Parameter \#1 \$url of function parse_url expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/FilterInput.php
 
 		-
 			message: '#^Parameter \#2 \$haystack of function in_array expects array, mixed given\.$#'
@@ -498,11 +493,6 @@ parameters:
 			count: 4
 			path: src/FilterInput.php
 
-		-
-			message: '#^Parameter \#2 \$subject of function preg_match expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/FilterInput.php
 
 		-
 			message: '#^Parameter \#3 \$encoding of function html_entity_decode expects string\|null, mixed given\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -483,7 +483,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$string of function trim expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/FilterInput.php
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,18 +91,6 @@ parameters:
 			path: src/Database/Migrate.php
 
 		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: src/Database/TableLoad.php
-
-		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 1
-			path: src/Database/TableLoad.php
-
-		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
 			count: 1
@@ -115,8 +103,8 @@ parameters:
 			path: src/Database/TableLoad.php
 
 		-
-			message: '#^Method Xmf\\Database\\TableLoad\:\:loadTableFromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: '#^Parameter \#2 \$data of static method Xmf\\Database\\TableLoad\:\:loadTableFromArray\(\) expects array\<int, array\<string, mixed\>\>, array given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Database/TableLoad.php
 

--- a/src/Database/TableLoad.php
+++ b/src/Database/TableLoad.php
@@ -58,7 +58,7 @@ class TableLoad
                     $valueClause .= ', ';
                 }
 
-                $insertInto .= '`' . $column . '`';
+                $insertInto .= '`' . str_replace('`', '``', (string) $column) . '`';
                 $valueClause .= $db->quote($value);
             }
 

--- a/src/Database/TableLoad.php
+++ b/src/Database/TableLoad.php
@@ -31,10 +31,10 @@ class TableLoad
     /**
      * loadTableFromArray
      *
-     * @param string $table name of table to load without prefix
-     * @param array  $data  array of rows to insert
-     *                      Each element of the outer array represents a single table row.
-     *                      Each row is an associative array in 'column' => 'value' format.
+     * @param string                       $table name of table to load without prefix
+     * @param array<int, array<string, mixed>> $data  array of rows to insert
+     *                                         Each element of the outer array represents a single table row.
+     *                                         Each row is an associative array in 'column' => 'value' format.
      *
      * @return int number of rows inserted
      */
@@ -58,7 +58,7 @@ class TableLoad
                     $valueClause .= ', ';
                 }
 
-                $insertInto .= '`' . str_replace('`', '``', (string) $column) . '`';
+                $insertInto .= '`' . str_replace('`', '``', $column) . '`';
                 $valueClause .= $db->quote($value);
             }
 

--- a/src/Database/Tables.php
+++ b/src/Database/Tables.php
@@ -904,8 +904,8 @@ class Tables
             return ' DEFAULT CURRENT_TIMESTAMP ';
         }
 
-        // surround default with quotes
-        return " DEFAULT '{$default}' ";
+        // surround default with quotes — escape embedded single quotes for valid DDL
+        return " DEFAULT '" . str_replace("'", "''", $default) . "' ";
     }
 
     /**

--- a/src/Database/index.php
+++ b/src/Database/index.php
@@ -1,3 +1,4 @@
 <?php
 
-    header('HTTP/1.0 404 Not Found');
+    http_response_code(404);
+    exit;

--- a/src/FilterInput.php
+++ b/src/FilterInput.php
@@ -275,12 +275,15 @@ class FilterInput
                 if (str_starts_with($result, '//')) {
                     $result = '';
                 }
-                $urlparts = parse_url($result);
-                if (
-                    !empty($urlparts['scheme'])
-                    && !($urlparts['scheme'] === 'http' || $urlparts['scheme'] === 'https')
-                ) {
-                    $result = '';
+                if ($result !== '') {
+                    $urlparts = parse_url($result);
+                    if (
+                        is_array($urlparts)
+                        && !empty($urlparts['scheme'])
+                        && !($urlparts['scheme'] === 'http' || $urlparts['scheme'] === 'https')
+                    ) {
+                        $result = '';
+                    }
                 }
                 // do not allow quotes, tag brackets or controls
                 if (!preg_match('#^[^"<>\x00-\x1F]+$#', $result)) {

--- a/src/FilterInput.php
+++ b/src/FilterInput.php
@@ -269,9 +269,10 @@ class FilterInput
                 break;
 
             case 'WEBURL':
+                /** @var string $result */
                 $result = (string) $this->process($source);
                 // reject protocol-relative URLs (//evil.example) and non-http(s) schemes
-                if (str_starts_with((string) $result, '//')) {
+                if (str_starts_with($result, '//')) {
                     $result = '';
                 }
                 $urlparts = parse_url($result);

--- a/src/FilterInput.php
+++ b/src/FilterInput.php
@@ -270,7 +270,7 @@ class FilterInput
 
             case 'WEBURL':
                 /** @var string $result */
-                $result = (string) $this->process($source);
+                $result = trim((string) $this->process($source));
                 // reject protocol-relative URLs (//evil.example) and non-http(s) schemes
                 if (str_starts_with($result, '//')) {
                     $result = '';

--- a/src/FilterInput.php
+++ b/src/FilterInput.php
@@ -270,7 +270,10 @@ class FilterInput
 
             case 'WEBURL':
                 $result = (string) $this->process($source);
-                // allow only relative, http or https
+                // reject protocol-relative URLs (//evil.example) and non-http(s) schemes
+                if (str_starts_with((string) $result, '//')) {
+                    $result = '';
+                }
                 $urlparts = parse_url($result);
                 if (
                     !empty($urlparts['scheme'])

--- a/src/Jwt/JsonWebToken.php
+++ b/src/Jwt/JsonWebToken.php
@@ -92,7 +92,7 @@ class JsonWebToken
                 return false;
             }
 
-            if ($values->$claim != $assert) {
+            if ($values->$claim !== $assert) {
                 return false;
             }
         }

--- a/src/Jwt/TokenReader.php
+++ b/src/Jwt/TokenReader.php
@@ -104,11 +104,15 @@ class TokenReader
             return false;
         }
         $header = trim($header);
-        $space = strpos($header, ' '); // expecting "Bearer base64-token-string"
-        if (false !== $space) {
-            $header = substr($header, $space);
+        if (strcasecmp($headerName, 'Authorization') === 0) {
+            $parts = explode(' ', $header, 2);
+            if (count($parts) !== 2 || strcasecmp($parts[0], 'Bearer') !== 0) {
+                return false;
+            }
+            $token = trim($parts[1]);
+        } else {
+            $token = $header;
         }
-        $token = trim($header);
         return static::fromString($key, $token, $assertClaims);
     }
 }

--- a/src/Jwt/index.php
+++ b/src/Jwt/index.php
@@ -1,3 +1,4 @@
 <?php
 
-    header('HTTP/1.0 404 Not Found');
+    http_response_code(404);
+    exit;

--- a/src/Key/index.php
+++ b/src/Key/index.php
@@ -1,3 +1,4 @@
 <?php
 
-    header('HTTP/1.0 404 Not Found');
+    http_response_code(404);
+    exit;

--- a/src/Mail/SendmailRunner.php
+++ b/src/Mail/SendmailRunner.php
@@ -220,6 +220,11 @@ final class SendmailRunner
             $stdinOpen = true;
             $chunkSize = 8192;
 
+            if ($len === 0) {
+                fclose($stdin);
+                $stdinOpen = false;
+            }
+
             while ($stdinOpen || !feof($stdoutPipe) || !feof($stderrPipe)) {
                 $read = [];
                 $write = [];

--- a/src/Metagen.php
+++ b/src/Metagen.php
@@ -404,7 +404,7 @@ class Metagen
         $text = str_replace('<br/>', ' ', $text);
         $text = str_replace('<br', ' ', $text);
         $text = strip_tags($text);
-        $text = html_entity_decode($text);
+        $text = html_entity_decode($text, ENT_QUOTES, self::ENCODING);
         $text = htmlspecialchars_decode($text, ENT_QUOTES);
         $text = str_replace(')', ' ', $text);
         $text = str_replace('(', ' ', $text);
@@ -416,7 +416,7 @@ class Metagen
         $text = str_replace('?', ' ', $text);
         $text = str_replace('"', ' ', $text);
         $text = str_replace('-', ' ', $text);
-        $text = str_replace('\n', ' ', $text);
+        $text = str_replace(["\r", "\n"], ' ', $text);
         $text = str_replace('&#8213;', ' ', $text);
 
         if ($keyword) {

--- a/src/Module/Helper/index.php
+++ b/src/Module/Helper/index.php
@@ -1,3 +1,4 @@
 <?php
 
-    header('HTTP/1.0 404 Not Found');
+    http_response_code(404);
+    exit;

--- a/src/Module/index.php
+++ b/src/Module/index.php
@@ -1,3 +1,4 @@
 <?php
 
-    header('HTTP/1.0 404 Not Found');
+    http_response_code(404);
+    exit;

--- a/src/Security/DecompressionException.php
+++ b/src/Security/DecompressionException.php
@@ -17,7 +17,7 @@ namespace Xmf\Security;
 /**
  * Thrown when gzip decompression fails or produces unsafe output.
  *
- * @category  Xmf\Security\DecompressionException
+ * @category  Xmf\Security
  * @package   Xmf
  * @author    Richard Griffith <richard@geekwright.com>
  * @copyright 2000-2026 XOOPS Project (https://xoops.org)

--- a/src/Security/DecompressionException.php
+++ b/src/Security/DecompressionException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ You may not change or alter any portion of this comment or credits
+ of supporting developers from this source code or any supporting source code
+ which is considered copyrighted (c) material of the original comment or credit authors.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+namespace Xmf\Security;
+
+/**
+ * Thrown when gzip decompression fails or produces unsafe output.
+ *
+ * @category  Xmf\Security\DecompressionException
+ * @package   Xmf
+ * @author    Richard Griffith <richard@geekwright.com>
+ * @copyright 2000-2026 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      https://xoops.org
+ */
+class DecompressionException extends \RuntimeException
+{
+}

--- a/src/Security/Serializer.php
+++ b/src/Security/Serializer.php
@@ -660,13 +660,13 @@ final class Serializer
      *
      * @return string decompressed data
      *
-     * @throws RuntimeException on decompression failure or size exceeded
+     * @throws DecompressionException on decompression failure or size exceeded
      */
     private static function safeGzipDecode(string $data): string
     {
         $context = inflate_init(ZLIB_ENCODING_GZIP);
         if ($context === false) {
-            throw new RuntimeException('Failed to initialize gzip decompression');
+            throw new DecompressionException('Failed to initialize gzip decompression');
         }
 
         $output = '';
@@ -680,23 +680,29 @@ final class Serializer
 
             $inflated = inflate_add($context, $chunk);
             if ($inflated === false) {
-                throw new RuntimeException('Gzip decompression failed');
+                throw new DecompressionException('Gzip decompression failed');
             }
             $output .= $inflated;
 
             if (\strlen($output) > $maxSize) {
-                throw new RuntimeException(
+                throw new DecompressionException(
                     sprintf('Decompressed payload exceeds %d bytes', $maxSize)
                 );
             }
         }
 
-        // Flush remaining
+        // Flush remaining and verify stream completed
         $inflated = inflate_add($context, '', ZLIB_FINISH);
-        if ($inflated !== false && $inflated !== '') {
+        if ($inflated === false) {
+            throw new DecompressionException('Gzip decompression failed during final flush');
+        }
+        if (inflate_get_status($context) !== ZLIB_STREAM_END) {
+            throw new DecompressionException('Gzip stream is incomplete or truncated');
+        }
+        if ($inflated !== '') {
             $output .= $inflated;
             if (\strlen($output) > $maxSize) {
-                throw new RuntimeException(
+                throw new DecompressionException(
                     sprintf('Decompressed payload exceeds %d bytes', $maxSize)
                 );
             }

--- a/src/Security/Serializer.php
+++ b/src/Security/Serializer.php
@@ -327,14 +327,9 @@ final class Serializer
         // Validate size after decoding
         self::validateSize($decoded);
 
-        // Check for optional gzip compression
+        // Check for optional gzip compression — stream-decompress to enforce size cap
         if (self::isGzip($decoded)) {
-            $unzipped = gzdecode($decoded);
-            if ($unzipped === false) {
-                throw new RuntimeException('Gzip decompression failed');
-            }
-            $decoded = $unzipped;
-            self::validateSize($decoded);
+            $decoded = self::safeGzipDecode($decoded);
         }
 
         self::logLegacy($payload);
@@ -652,6 +647,62 @@ final class Serializer
                 sprintf('Decoded payload exceeds %d bytes', self::MAX_SIZE)
             );
         }
+    }
+
+    /**
+     * Decompress gzip data with streaming size enforcement.
+     *
+     * Uses inflate_init()/inflate_add() to decompress in chunks, aborting
+     * as soon as output exceeds MAX_SIZE. This prevents a small compressed
+     * payload from consuming unbounded memory during decompression.
+     *
+     * @param string $data gzip-compressed data
+     *
+     * @return string decompressed data
+     *
+     * @throws RuntimeException on decompression failure or size exceeded
+     */
+    private static function safeGzipDecode(string $data): string
+    {
+        $context = inflate_init(ZLIB_ENCODING_GZIP);
+        if ($context === false) {
+            throw new RuntimeException('Failed to initialize gzip decompression');
+        }
+
+        $output = '';
+        $offset = 0;
+        $chunkSize = 8192;
+        $maxSize = self::MAX_SIZE;
+
+        while ($offset < \strlen($data)) {
+            $chunk = substr($data, $offset, $chunkSize);
+            $offset += \strlen($chunk);
+
+            $inflated = inflate_add($context, $chunk);
+            if ($inflated === false) {
+                throw new RuntimeException('Gzip decompression failed');
+            }
+            $output .= $inflated;
+
+            if (\strlen($output) > $maxSize) {
+                throw new RuntimeException(
+                    sprintf('Decompressed payload exceeds %d bytes', $maxSize)
+                );
+            }
+        }
+
+        // Flush remaining
+        $inflated = inflate_add($context, '', ZLIB_FINISH);
+        if ($inflated !== false && $inflated !== '') {
+            $output .= $inflated;
+            if (\strlen($output) > $maxSize) {
+                throw new RuntimeException(
+                    sprintf('Decompressed payload exceeds %d bytes', $maxSize)
+                );
+            }
+        }
+
+        return $output;
     }
 
     /**

--- a/src/Yaml.php
+++ b/src/Yaml.php
@@ -140,10 +140,9 @@ class Yaml
     /**
      * Dump an PHP array as a YAML string with a php wrapper
      *
-     * The wrap is a php header that surrounds the yaml with section markers,
-     * '---' and '...' along with php comment markers. The php wrapper keeps the
-     * yaml file contents from being revealed by serving the file directly from
-     * a poorly configured server.
+     * The wrap is a php exit guard followed by YAML section markers '---' and
+     * '...'. The php wrapper prevents the file contents from being revealed
+     * by serving the file directly from a poorly configured server.
      *
      * @param mixed   $var    Variable which will be dumped
      * @param integer $inline Nesting level where you switch to inline YAML
@@ -155,7 +154,7 @@ class Yaml
     {
         try {
             $yamlString = VendorYaml::dump($var, $inline, $indent);
-            $ret = empty($yamlString) ? false : "<?php\n/*\n---\n" . $yamlString . "\n...\n*/\n";
+            $ret = empty($yamlString) ? false : "<?php exit; ?>\n---\n" . $yamlString . "\n...\n";
         } catch (\Throwable $e) {
             static::logError($e);
             $ret = false;

--- a/src/Yaml.php
+++ b/src/Yaml.php
@@ -140,9 +140,10 @@ class Yaml
     /**
      * Dump an PHP array as a YAML string with a php wrapper
      *
-     * The wrap is a php exit guard followed by YAML section markers '---' and
-     * '...'. The php wrapper prevents the file contents from being revealed
-     * by serving the file directly from a poorly configured server.
+     * The wrap is a php __halt_compiler() guard followed by YAML section markers
+     * '---' and '...'. The guard stops the PHP lexer entirely, preventing the
+     * file contents from being parsed or revealed by serving the file directly
+     * from a poorly configured server.
      *
      * @param mixed   $var    Variable which will be dumped
      * @param integer $inline Nesting level where you switch to inline YAML
@@ -154,7 +155,7 @@ class Yaml
     {
         try {
             $yamlString = VendorYaml::dump($var, $inline, $indent);
-            $ret = empty($yamlString) ? false : "<?php exit; ?>\n---\n" . $yamlString . "\n...\n";
+            $ret = empty($yamlString) ? false : "<?php __halt_compiler(); ?>\n---\n" . $yamlString . "\n...\n";
         } catch (\Throwable $e) {
             static::logError($e);
             $ret = false;
@@ -165,10 +166,9 @@ class Yaml
     /**
      * Load a YAML string with a php wrapper into a PHP array
      *
-     * The wrap is a php header that surrounds the yaml with section markers,
-     * '---' and '...' along with php comment markers. The php wrapper keeps the
-     * yaml file contents from being revealed by serving the file directly from
-     * a poorly configured server.
+     * Supports both the current __halt_compiler() guard format and the legacy
+     * PHP block comment format. Content between '---' and '...' markers is
+     * extracted regardless of wrapper style.
      *
      * @param string $yamlString YAML dump string
      *
@@ -208,10 +208,9 @@ class Yaml
     /**
      * Read a file containing YAML with a php wrapper into a PHP array
      *
-     * The wrap is a php header that surrounds the yaml with section markers,
-     * '---' and '...' along with php comment markers. The php wrapper keeps the
-     * yaml file contents from being revealed by serving the file directly from
-     * a poorly configured server.
+     * Supports both the current __halt_compiler() guard format and the legacy
+     * PHP block comment format. Content between '---' and '...' markers is
+     * extracted regardless of wrapper style.
      *
      * @param string $yamlFile filename of YAML file
      *

--- a/src/index.php
+++ b/src/index.php
@@ -1,3 +1,4 @@
 <?php
 
-    header('HTTP/1.0 404 Not Found');
+    http_response_code(404);
+    exit;

--- a/tests/unit/Database/TablesTest.php
+++ b/tests/unit/Database/TablesTest.php
@@ -139,6 +139,27 @@ class TablesTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array(), $tables->dumpQueue());
     }
 
+    public function testQuoteDefaultClauseEscapesSingleQuotes()
+    {
+        $tables = new TestableTables();
+        $result = $tables->callQuoteDefaultClause("O'Reilly");
+        $this->assertSame(" DEFAULT 'O''Reilly' ", $result);
+    }
+
+    public function testQuoteDefaultClauseNullReturnsEmpty()
+    {
+        $tables = new TestableTables();
+        $result = $tables->callQuoteDefaultClause(null);
+        $this->assertSame('', $result);
+    }
+
+    public function testQuoteDefaultClauseCurrentTimestamp()
+    {
+        $tables = new TestableTables();
+        $result = $tables->callQuoteDefaultClause('CURRENT_TIMESTAMP');
+        $this->assertSame(' DEFAULT CURRENT_TIMESTAMP ', $result);
+    }
+
     private function captureWarning(callable $callback): string
     {
         $warning = '';
@@ -178,6 +199,11 @@ class TestableTables extends Tables
     public function callRenderTableCreate(string $table, bool $prefixed = false): string|false
     {
         return $this->renderTableCreate($table, $prefixed);
+    }
+
+    public function callQuoteDefaultClause(?string $default): string
+    {
+        return $this->quoteDefaultClause($default);
     }
 }
 

--- a/tests/unit/FilterInputTest.php
+++ b/tests/unit/FilterInputTest.php
@@ -122,6 +122,12 @@ class FilterInputTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('/local/path', $result);
     }
 
+    public function testWeburlRejectsProtocolRelativeUrlWithLeadingWhitespace()
+    {
+        $result = FilterInput::clean('  //evil.example/path', 'WEBURL');
+        $this->assertSame('', $result);
+    }
+
     public function testWeburlRejectsJavascriptScheme()
     {
         $result = FilterInput::clean('javascript:alert(1)', 'WEBURL');

--- a/tests/unit/FilterInputTest.php
+++ b/tests/unit/FilterInputTest.php
@@ -104,6 +104,30 @@ class FilterInputTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testWeburlRejectsProtocolRelativeUrl()
+    {
+        $result = FilterInput::clean('//evil.example/path', 'WEBURL');
+        $this->assertSame('', $result);
+    }
+
+    public function testWeburlAllowsHttpUrl()
+    {
+        $result = FilterInput::clean('http://example.com/page', 'WEBURL');
+        $this->assertSame('http://example.com/page', $result);
+    }
+
+    public function testWeburlAllowsRelativeUrl()
+    {
+        $result = FilterInput::clean('/local/path', 'WEBURL');
+        $this->assertSame('/local/path', $result);
+    }
+
+    public function testWeburlRejectsJavascriptScheme()
+    {
+        $result = FilterInput::clean('javascript:alert(1)', 'WEBURL');
+        $this->assertSame('', $result);
+    }
+
     /**
      * @dataProvider getTestForCleanVarType
      */

--- a/tests/unit/Jwt/JsonWebTokenTest.php
+++ b/tests/unit/Jwt/JsonWebTokenTest.php
@@ -80,4 +80,22 @@ class JsonWebTokenTest extends \PHPUnit\Framework\TestCase
         $actual = @$decoder->decode($token);
         $this->assertFalse($actual);
     }
+
+    public function testDecodeStrictClaimComparison()
+    {
+        $token = $this->object->create(['uid' => 1], 60);
+        $this->assertIsString($token);
+
+        // strict match succeeds
+        $result = $this->object->decode($token, ['uid' => 1]);
+        $this->assertIsObject($result);
+        $this->assertSame(1, $result->uid);
+
+        // loose match that would pass with == but fails with ===
+        $result = $this->object->decode($token, ['uid' => '1']);
+        $this->assertFalse($result);
+
+        $result = $this->object->decode($token, ['uid' => true]);
+        $this->assertFalse($result);
+    }
 }

--- a/tests/unit/Jwt/TokenReaderTest.php
+++ b/tests/unit/Jwt/TokenReaderTest.php
@@ -74,11 +74,55 @@ class TokenReaderTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testFromHeader()
+    /**
+     * Test fromHeader by running in a separate process to avoid static cache issues.
+     *
+     * @runInSeparateProcess
+     */
+    public function testFromHeaderWithBearerScheme()
     {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
+        $claims = array('rat' => 'cute');
+        $jwt = new JsonWebToken($this->testKey);
+        $token = $jwt->create($claims, 60);
+
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token;
+        $actual = TokenReader::fromHeader($this->testKey, $claims);
+        $this->assertIsObject($actual);
+        $this->assertSame('cute', $actual->rat);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFromHeaderRejectsNonBearerScheme()
+    {
+        $_SERVER['HTTP_AUTHORIZATION'] = 'Basic dXNlcjpwYXNz';
+        $actual = TokenReader::fromHeader($this->testKey);
+        $this->assertFalse($actual);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFromHeaderAcceptsBareTokenOnCustomHeader()
+    {
+        $claims = array('rat' => 'cute');
+        $jwt = new JsonWebToken($this->testKey);
+        $token = $jwt->create($claims, 60);
+
+        $_SERVER['HTTP_X_AUTH_TOKEN'] = $token;
+        $actual = TokenReader::fromHeader($this->testKey, $claims, 'X-Auth-Token');
+        $this->assertIsObject($actual);
+        $this->assertSame('cute', $actual->rat);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFromHeaderRejectsEmptyHeader()
+    {
+        unset($_SERVER['HTTP_AUTHORIZATION']);
+        $actual = TokenReader::fromHeader($this->testKey);
+        $this->assertFalse($actual);
     }
 }

--- a/tests/unit/Mail/SendmailRunnerTest.php
+++ b/tests/unit/Mail/SendmailRunnerTest.php
@@ -98,6 +98,23 @@ class SendmailRunnerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('sendmail warning (success): minor warning\n', $warning);
     }
 
+    public function testDeliverEmptyPayloadDoesNotHang()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Sendmail runner process test requires a POSIX shell.');
+        }
+
+        $outputFile = $this->createTempFile('sendmail-output-', '');
+        $script = $this->createExecutableScript(
+            "#!/usr/bin/env bash\ncat > " . escapeshellarg($outputFile) . "\nexit 0\n"
+        );
+        $runner = new SendmailRunner(array($script));
+
+        $runner->deliver($script, '');
+
+        $this->assertSame('', file_get_contents($outputFile));
+    }
+
     private function createTempFile(string $prefix, string $contents): string
     {
         $path = tempnam(sys_get_temp_dir(), $prefix);

--- a/tests/unit/MetagenTest.php
+++ b/tests/unit/MetagenTest.php
@@ -227,4 +227,24 @@ EOT;
         $this->assertStringContainsString($expected, $actual);
         $this->assertStringNotContainsString('&#8364;', $actual);
     }
+
+    public function testPurifyTextReplacesNewlines()
+    {
+        $method = new \ReflectionMethod('Xmf\Metagen', 'purifyText');
+        $actual = $method->invokeArgs(null, array("line one\nline two\rline three"));
+        $this->assertStringNotContainsString("\n", $actual);
+        $this->assertStringNotContainsString("\r", $actual);
+        $this->assertStringContainsString('line one', $actual);
+        $this->assertStringContainsString('line two', $actual);
+        $this->assertStringContainsString('line three', $actual);
+    }
+
+    public function testPurifyTextDecodesEntitiesWithEncoding()
+    {
+        $method = new \ReflectionMethod('Xmf\Metagen', 'purifyText');
+        $input = 'caf&eacute; cr&egrave;me';
+        $actual = $method->invokeArgs(null, array($input));
+        $this->assertStringContainsString('café', $actual);
+        $this->assertStringContainsString('crème', $actual);
+    }
 }

--- a/tests/unit/MetagenTest.php
+++ b/tests/unit/MetagenTest.php
@@ -231,6 +231,7 @@ EOT;
     public function testPurifyTextReplacesNewlines()
     {
         $method = new \ReflectionMethod('Xmf\Metagen', 'purifyText');
+        $method->setAccessible(true);
         $actual = $method->invokeArgs(null, array("line one\nline two\rline three"));
         $this->assertStringNotContainsString("\n", $actual);
         $this->assertStringNotContainsString("\r", $actual);
@@ -242,6 +243,7 @@ EOT;
     public function testPurifyTextDecodesEntitiesWithEncoding()
     {
         $method = new \ReflectionMethod('Xmf\Metagen', 'purifyText');
+        $method->setAccessible(true);
         $input = 'caf&eacute; cr&egrave;me';
         $actual = $method->invokeArgs(null, array($input));
         $this->assertStringContainsString('café', $actual);

--- a/tests/unit/YamlTest.php
+++ b/tests/unit/YamlTest.php
@@ -105,6 +105,50 @@ class YamlTest extends \PHPUnit\Framework\TestCase
         unlink($tmpfname);
     }
 
+    public function testDumpAndLoadWrappedWithClosingCommentSequence()
+    {
+        $inputArray = array('value' => 'contains */ closing comment', 'nested' => array('a' => '*/'));
+
+        $string = Yaml::dumpWrapped($inputArray);
+        $this->assertNotFalse($string);
+        $this->assertIsString($string);
+
+        $outputArray = Yaml::loadWrapped((string) $string);
+        $this->assertIsArray($outputArray);
+        $this->assertSame($inputArray, $outputArray);
+    }
+
+    public function testDumpWrappedUsesHaltCompilerGuard()
+    {
+        $inputArray = array('key' => 'value');
+        $string = Yaml::dumpWrapped($inputArray);
+        $this->assertIsString($string);
+        $this->assertStringStartsWith('<?php __halt_compiler(); ?>', (string) $string);
+    }
+
+    public function testDumpAndLoadWrappedWithPhpTag()
+    {
+        $inputArray = array('code' => '<?php echo "hello"; ?>');
+
+        $string = Yaml::dumpWrapped($inputArray);
+        $this->assertNotFalse($string);
+        $this->assertIsString($string);
+
+        $outputArray = Yaml::loadWrapped((string) $string);
+        $this->assertIsArray($outputArray);
+        $this->assertSame($inputArray, $outputArray);
+    }
+
+    public function testLoadWrappedReadsOldCommentFormat()
+    {
+        $inputArray = array('one' => 1, 'two' => 'hello');
+        $oldFormat = "<?php\n/*\n---\none: 1\ntwo: hello\n...\n*/\n";
+
+        $outputArray = Yaml::loadWrapped($oldFormat);
+        $this->assertIsArray($outputArray);
+        $this->assertSame($inputArray, $outputArray);
+    }
+
     public function testReadNoFile()
     {
         $this->assertFalse(Yaml::read('./no-such-file'));


### PR DESCRIPTION
  - Yaml dumpWrapped: use exit guard instead of PHP comment to prevent code execution when content contains closing comment sequence
  - JWT JsonWebToken: use strict comparison for claim validation
  - JWT TokenReader: validate Bearer scheme on Authorization header only; custom headers still accept bare tokens for backward compatibility
  - Metagen purifyText: add explicit encoding, fix newline replacement
  - SendmailRunner: close stdin immediately on empty payload to prevent hang
  - TableLoad: escape backticks in column names
  - FilterInput WEBURL: reject protocol-relative URLs
  - Tables quoteDefaultClause: escape single quotes in DDL default values
  - Replace header('HTTP/1.0 404 Not Found') with http_response_code(404) in all directory index guards
  - Update CHANGELOG for 1.3.0-RC1
  - Update phpstan-baseline.neon for changed error signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Stricter JWT claim checks and Authorization header enforcement (Bearer only for Authorization; bare tokens allowed on custom headers)
  * Safer gzip decompression with streaming size checks and clearer decompression errors
  * Reject protocol‑relative URLs in web URL filtering
  * Improved escaping for SQL identifiers and DEFAULT values

* **Bug Fixes**
  * Prevent mail runner from hanging on empty messages
  * Fix text purification for proper entity decoding and newline removal
  * Unified 404 response handling across entry points

* **Changed**
  * Wrapped YAML format switched to a safer PHP exit guard while preserving legacy support

* **Chores**
  * Removed duplicate review tool configuration from CI config

* **Tests**
  * Added unit tests covering JWT, URL filtering, YAML wrappers, DB defaults, mail runner, decompression, and text purification
<!-- end of auto-generated comment: release notes by coderabbit.ai -->