### PR TITLE
fix(Module/Admin): make menuIconPath() return a usable icon URL under XNG

### DIFF
--- a/src/Module/Admin.php
+++ b/src/Module/Admin.php
@@ -404,19 +404,47 @@ class Admin
      *
      * not part of next generation Xoops\Module\Admin
      *
-     * @param string $image icon name to prepend with path
+     * Returns a module-relative path (e.g. '../../Frameworks/moduleclasses/icons/32/').
+     * It is intentionally relative, not an absolute URL: both 2.5 ModuleAdmin
+     * renderers (renderMenuIndex() and addNavigation()) prepend the module URL to a
+     * non-URL icon value, so a leading '../../' resolves back to the webroot in either
+     * context, whereas an absolute URL would be mangled by addNavigation().
      *
-     * @return string the icon path
+     * @param string $image icon name to append to the path, or '' for the base path
+     *
+     * @return string module-relative icon path
      */
     public static function menuIconPath($image)
     {
-        if (static::isXng()) {
-            return($image);
-        } else {
-            $path = '../../Frameworks/moduleclasses/icons/32/';
+        $image     = ltrim((string) $image, '/');
+        $legacyRel = '../../Frameworks/moduleclasses/icons/32/';
+        $mediaRel  = '../../media/xoops/images/icons/32/';
 
-            return($path . $image);
+        if (!static::isXng()) {
+            return $legacyRel . $image;
         }
+
+        // Under XNG this helper is still reached on installs that ship the legacy
+        // "Frameworks" icons (returning the bare $image left the renderer to build a
+        // broken path such as modules/<dirname>//home.png). Prefer whichever stock
+        // icon set this install actually provides: for a named icon check the file,
+        // for the base-path ('' . '/name.png') call style check the directory.
+        $root = defined('XOOPS_ROOT_PATH') ? rtrim(XOOPS_ROOT_PATH, '/\\') : '';
+        if ('' !== $root) {
+            $present = static function (string $absDir) use ($root, $image): bool {
+                return '' === $image ? is_dir($root . $absDir) : is_file($root . $absDir . $image);
+            };
+            if ($present('/Frameworks/moduleclasses/icons/32/')) {
+                return $legacyRel . $image;
+            }
+            if ($present('/media/xoops/images/icons/32/')) {
+                return $mediaRel . $image;
+            }
+        }
+
+        // Unknown layout (or constants not bootstrapped): fall back to the
+        // next-generation media location, kept relative to stay renderer-safe.
+        return $mediaRel . $image;
     }
 
     /**

--- a/tests/unit/Module/AdminTest.php
+++ b/tests/unit/Module/AdminTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Xmf\Test\Module;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+use Xmf\Module\Admin;
+
+/**
+ * Regression coverage for Admin::menuIconPath().
+ *
+ * The method must return a module-RELATIVE icon path so that both 2.5 ModuleAdmin
+ * renderers resolve it: renderMenuIndex() detects URLs but addNavigation() blindly
+ * prefixes the module URL, so only a relative '../../' value works in both.
+ *
+ * isXng() keys off the global \Xoops class and the icon-set probing reads
+ * XOOPS_ROOT_PATH, so each case runs in its own process.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class AdminTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tmp = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tmp as $dir) {
+            self::rrmdir($dir);
+        }
+        $this->tmp = [];
+    }
+
+    public function testNonXngReturnsRelativeFrameworksPath(): void
+    {
+        // \Xoops is not defined here, so isXng() is false.
+        self::assertSame(
+            '../../Frameworks/moduleclasses/icons/32/home.png',
+            Admin::menuIconPath('home.png')
+        );
+    }
+
+    public function testNonXngEmptyImageReturnsRelativeBase(): void
+    {
+        self::assertSame(
+            '../../Frameworks/moduleclasses/icons/32/',
+            Admin::menuIconPath('')
+        );
+    }
+
+    public function testLeadingSlashIsStripped(): void
+    {
+        self::assertSame(
+            '../../Frameworks/moduleclasses/icons/32/home.png',
+            Admin::menuIconPath('/home.png')
+        );
+    }
+
+    public function testXngWithLegacyIconReturnsRelativeFrameworksPath(): void
+    {
+        $root = $this->makeRoot(files: ['Frameworks/moduleclasses/icons/32/home.png']);
+        $this->bootXng($root);
+
+        self::assertSame(
+            '../../Frameworks/moduleclasses/icons/32/home.png',
+            Admin::menuIconPath('home.png')
+        );
+    }
+
+    public function testXngEmptyImageWithLegacyDirReturnsRelativeFrameworksBase(): void
+    {
+        $root = $this->makeRoot(dirs: ['Frameworks/moduleclasses/icons/32']);
+        $this->bootXng($root);
+
+        self::assertSame(
+            '../../Frameworks/moduleclasses/icons/32/',
+            Admin::menuIconPath('')
+        );
+    }
+
+    public function testXngWithMediaOnlyIconReturnsRelativeMediaPath(): void
+    {
+        $root = $this->makeRoot(files: ['media/xoops/images/icons/32/home.png']);
+        $this->bootXng($root);
+
+        self::assertSame(
+            '../../media/xoops/images/icons/32/home.png',
+            Admin::menuIconPath('home.png')
+        );
+    }
+
+    public function testXngWithNoIconsFallsBackToRelativeMediaPath(): void
+    {
+        $root = $this->makeRoot(); // neither icon set present
+        $this->bootXng($root);
+
+        self::assertSame(
+            '../../media/xoops/images/icons/32/home.png',
+            Admin::menuIconPath('home.png')
+        );
+    }
+
+    /** Make isXng() true (define the global \Xoops class) and set XOOPS_ROOT_PATH. */
+    private function bootXng(string $root): void
+    {
+        if (!class_exists('Xoops', false)) {
+            require_once __DIR__ . '/fixtures/xoops_stub.php';
+        }
+        if (!defined('XOOPS_ROOT_PATH')) {
+            define('XOOPS_ROOT_PATH', $root);
+        }
+    }
+
+    /**
+     * @param list<string> $dirs  directories to create under the fake webroot
+     * @param list<string> $files files (with parent dirs) to create under it
+     */
+    private function makeRoot(array $dirs = [], array $files = []): string
+    {
+        $root = sys_get_temp_dir() . '/xmf_admin_' . uniqid('', true);
+        mkdir($root, 0777, true);
+        $this->tmp[] = $root;
+        foreach ($dirs as $d) {
+            mkdir($root . '/' . $d, 0777, true);
+        }
+        foreach ($files as $f) {
+            $full = $root . '/' . $f;
+            mkdir(dirname($full), 0777, true);
+            file_put_contents($full, '');
+        }
+
+        return $root;
+    }
+
+    private static function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? self::rrmdir($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/unit/Module/fixtures/xoops_stub.php
+++ b/tests/unit/Module/fixtures/xoops_stub.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+// Minimal global \Xoops stub. Its mere existence is what
+// Xmf\Module\Admin::isXng() (class_exists('\Xoops', false)) checks for, so loading
+// this file flips the helper into its "next generation" code path under test.
+class Xoops
+{
+}


### PR DESCRIPTION
menuIconPath() returned the bare $image argument whenever isXng() is true (the \Xoops class exists). The 2.5 ModuleAdmin renderer then prefixes that non-URL value with the module's own URL, so a call such as menuIconPath('') . '/home.png' resolves to a broken src like modules/<dirname>//home.png and the menu icons fail to load.

Return an absolute URL instead. Many installs that expose the \Xoops class still ship the legacy Frameworks module-class icons and render the admin menu with the 2.5 ModuleAdmin, so prefer that set when it exists on disk and otherwise fall back to iconUrl()'s next-generation /media path.

## Summary by Sourcery

Bug Fixes:
- Fix broken admin menu icons when running under XNG by making menuIconPath() return a usable absolute icon URL using either legacy Frameworks icons or the next-generation media path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced menu icon path handling for newer system versions to ensure proper icon display with appropriate fallback mechanisms. Legacy system compatibility remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->