### PR TITLE
feat(Helper): add GenericHelper::relativeUrl() for root-relative module URLs (closes #39)

### DIFF
--- a/src/Module/Helper/GenericHelper.php
+++ b/src/Module/Helper/GenericHelper.php
@@ -31,6 +31,9 @@ use Xmf\Language;
  */
 abstract class GenericHelper extends AbstractHelper
 {
+    /** Path segment for the modules directory, relative to the site root. */
+    private const MODULE_PATH = '/modules/';
+
     /**
      * @var \XoopsModule
      * @deprecated - use $module -- will be removed
@@ -252,15 +255,18 @@ abstract class GenericHelper extends AbstractHelper
      */
     public function url($url = '')
     {
-        return XOOPS_URL . '/modules/' . $this->dirname . '/' . $url;
+        return XOOPS_URL . self::MODULE_PATH . $this->dirname . '/' . $url;
     }
 
     /**
      * Return a root relative URL for a module relative URL.
      *
-     * Unlike url(), this omits the XOOPS_URL scheme/host prefix and returns a
-     * path rooted at the site root, e.g. /modules/mymodule/assets/app.js. This
-     * is the form expected by APIs such as $xoTheme->addScript().
+     * Unlike url(), this omits the XOOPS_URL scheme and host and returns a path
+     * rooted at the web server root - the form expected by APIs such as
+     * $xoTheme->addScript(). The site's base path is taken from XOOPS_URL, so it
+     * is correct for a sub-directory install too:
+     *   root install    -> /modules/mymodule/assets/app.js
+     *   /xoops subfolder -> /xoops/modules/mymodule/assets/app.js
      *
      * @param string $url module relative URL
      *
@@ -268,7 +274,15 @@ abstract class GenericHelper extends AbstractHelper
      */
     public function relativeUrl($url = '')
     {
-        return '/modules/' . $this->dirname . '/' . $url;
+        $basePath = '';
+        if (defined('XOOPS_URL')) {
+            $urlPath = parse_url((string) XOOPS_URL, PHP_URL_PATH);
+            if (is_string($urlPath)) {
+                $basePath = rtrim($urlPath, '/');
+            }
+        }
+
+        return $basePath . self::MODULE_PATH . $this->dirname . '/' . ltrim($url, '/');
     }
 
     /**
@@ -280,7 +294,7 @@ abstract class GenericHelper extends AbstractHelper
      */
     public function path($path = '')
     {
-        return XOOPS_ROOT_PATH . '/modules/' . $this->dirname . '/' . $path;
+        return XOOPS_ROOT_PATH . self::MODULE_PATH . $this->dirname . '/' . $path;
     }
 
     /**

--- a/src/Module/Helper/GenericHelper.php
+++ b/src/Module/Helper/GenericHelper.php
@@ -256,6 +256,22 @@ abstract class GenericHelper extends AbstractHelper
     }
 
     /**
+     * Return a root relative URL for a module relative URL.
+     *
+     * Unlike url(), this omits the XOOPS_URL scheme/host prefix and returns a
+     * path rooted at the site root, e.g. /modules/mymodule/assets/app.js. This
+     * is the form expected by APIs such as $xoTheme->addScript().
+     *
+     * @param string $url module relative URL
+     *
+     * @return string
+     */
+    public function relativeUrl($url = '')
+    {
+        return '/modules/' . $this->dirname . '/' . $url;
+    }
+
+    /**
      * Return absolute filesystem path for a module relative path
      *
      * @param string $path module relative file system path

--- a/tests/unit/Module/Helper/GenericHelperTest.php
+++ b/tests/unit/Module/Helper/GenericHelperTest.php
@@ -4,47 +4,69 @@ declare(strict_types=1);
 
 namespace Xmf\Test\Module\Helper;
 
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
-use Xmf\Module\Helper as ModuleHelper;
-use Xmf\Module\Helper\AbstractHelper;
+use Xmf\Module\Helper\GenericHelper;
+
+/**
+ * Concrete test double that sets the dirname directly, bypassing the
+ * module-loading constructor - no reflection required.
+ */
+final class RelativeUrlTestHelper extends GenericHelper
+{
+    public function __construct($dirname)
+    {
+        $this->dirname = $dirname;
+    }
+}
 
 /**
  * Coverage for GenericHelper::relativeUrl() (issue #39).
  *
- * The helper's URL/path methods only depend on the resolved $dirname, so the
- * concrete Xmf\Module\Helper is created without its (module-loading) constructor
- * and the dirname is injected directly — no XOOPS runtime required.
+ * relativeUrl() reads XOOPS_URL (a constant), so each XOOPS_URL value is
+ * exercised in its own process.
  */
 final class GenericHelperTest extends TestCase
 {
-    private function helperForDirname(string $dirname): ModuleHelper
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testRelativeUrlAtWebRoot(): void
     {
-        $helper = (new \ReflectionClass(ModuleHelper::class))->newInstanceWithoutConstructor();
-        $prop   = new ReflectionProperty(AbstractHelper::class, 'dirname');
-        $prop->setAccessible(true);
-        $prop->setValue($helper, $dirname);
+        if (!defined('XOOPS_URL')) {
+            define('XOOPS_URL', 'https://example.test');
+        }
+        $helper = new RelativeUrlTestHelper('mymodule');
 
-        return $helper;
-    }
-
-    public function testRelativeUrlReturnsRootRelativePath(): void
-    {
-        $helper = $this->helperForDirname('mymodule');
         self::assertSame('/modules/mymodule/assets/app.js', $helper->relativeUrl('assets/app.js'));
-    }
-
-    public function testRelativeUrlWithNoArgumentReturnsModuleRoot(): void
-    {
-        $helper = $this->helperForDirname('mymodule');
         self::assertSame('/modules/mymodule/', $helper->relativeUrl());
     }
 
-    public function testRelativeUrlHasNoSchemeOrHost(): void
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testRelativeUrlInSubdirectoryInstall(): void
     {
-        $helper = $this->helperForDirname('mymodule');
+        if (!defined('XOOPS_URL')) {
+            define('XOOPS_URL', 'https://example.test/xoops');
+        }
+        $helper = new RelativeUrlTestHelper('mymodule');
+
+        self::assertSame('/xoops/modules/mymodule/assets/app.js', $helper->relativeUrl('assets/app.js'));
+        // A leading slash on the input must not double up.
+        self::assertSame('/xoops/modules/mymodule/assets/app.js', $helper->relativeUrl('/assets/app.js'));
+    }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testRelativeUrlStripsTrailingSlashOfBaseAndHasNoHost(): void
+    {
+        if (!defined('XOOPS_URL')) {
+            define('XOOPS_URL', 'https://example.test/sub/');
+        }
+        $helper = new RelativeUrlTestHelper('mymodule');
         $result = $helper->relativeUrl('x.css');
-        self::assertStringStartsWith('/modules/', $result);
+
+        self::assertSame('/sub/modules/mymodule/x.css', $result);
         self::assertStringNotContainsString('://', $result);
     }
 }

--- a/tests/unit/Module/Helper/GenericHelperTest.php
+++ b/tests/unit/Module/Helper/GenericHelperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Xmf\Test\Module\Helper;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Xmf\Module\Helper as ModuleHelper;
+use Xmf\Module\Helper\AbstractHelper;
+
+/**
+ * Coverage for GenericHelper::relativeUrl() (issue #39).
+ *
+ * The helper's URL/path methods only depend on the resolved $dirname, so the
+ * concrete Xmf\Module\Helper is created without its (module-loading) constructor
+ * and the dirname is injected directly — no XOOPS runtime required.
+ */
+final class GenericHelperTest extends TestCase
+{
+    private function helperForDirname(string $dirname): ModuleHelper
+    {
+        $helper = (new \ReflectionClass(ModuleHelper::class))->newInstanceWithoutConstructor();
+        $prop   = new ReflectionProperty(AbstractHelper::class, 'dirname');
+        $prop->setAccessible(true);
+        $prop->setValue($helper, $dirname);
+
+        return $helper;
+    }
+
+    public function testRelativeUrlReturnsRootRelativePath(): void
+    {
+        $helper = $this->helperForDirname('mymodule');
+        self::assertSame('/modules/mymodule/assets/app.js', $helper->relativeUrl('assets/app.js'));
+    }
+
+    public function testRelativeUrlWithNoArgumentReturnsModuleRoot(): void
+    {
+        $helper = $this->helperForDirname('mymodule');
+        self::assertSame('/modules/mymodule/', $helper->relativeUrl());
+    }
+
+    public function testRelativeUrlHasNoSchemeOrHost(): void
+    {
+        $helper = $this->helperForDirname('mymodule');
+        $result = $helper->relativeUrl('x.css');
+        self::assertStringStartsWith('/modules/', $result);
+        self::assertStringNotContainsString('://', $result);
+    }
+}


### PR DESCRIPTION
## What

Closes #39.

Adds `Xmf\Module\Helper\GenericHelper::relativeUrl($url = '')`, returning a
site-root-relative module web path, e.g. `/modules/mymodule/assets/app.js`.

## Why

`url()` returns an absolute URL (`XOOPS_URL/modules/...`) and `path()` a filesystem
path (`XOOPS_ROOT_PATH/modules/...`). Neither gives the root-relative web path that
APIs such as `$xoTheme->addScript()` expect. Rather than overload `path()` with a
boolean flag (which would mix filesystem and URL semantics), this adds an explicit,
self-describing method that mirrors `url()` without the scheme/host prefix.

```php
$helper = \Xmf\Module\Helper::getHelper('mymodule');
$helper->relativeUrl('assets/app.js'); // "/modules/mymodule/assets/app.js"
```

Backward compatible — new method only.

## Tests

`tests/unit/Module/Helper/GenericHelperTest.php` — 3 cases (path, empty arg, no
scheme/host). The concrete `Xmf\Module\Helper` is instantiated without its
module-loading constructor and `$dirname` is injected, so no XOOPS runtime is needed.

## Summary by Sourcery

Add support for generating root-relative module URLs and cover the new behavior with unit tests.

New Features:
- Introduce GenericHelper::relativeUrl() to return site-root-relative URLs for module assets.

Tests:
- Add GenericHelperTest to validate relativeUrl() output for paths, empty arguments, and absence of scheme/host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new method to generate root-relative module resource URLs, complementing existing absolute URL generation capabilities.

* **Tests**
  * Added comprehensive test coverage for the new URL generation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->